### PR TITLE
Bump to Bitcoin 0.32.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,34 +10,10 @@ repository = "https://github.com/FairgateLabs/rust-bitcoin-script-stack"
 
 [dependencies]
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
-bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", branch = "bitvm" }
 bitcoin-scriptexec = { git = "https://github.com/BitVM/rust-bitcoin-scriptexec/"}
-crossterm = { version = "0.27.0", optional = true}
+bitcoin = "0.32.5"
+crossterm = { version = "0.27.0", optional = true }
 hex = "0.4.3"
 
 [features]
 interactive = ["crossterm"]
-
-[patch.crates-io.base58check]
-git = "https://github.com/rust-bitcoin/rust-bitcoin"
-branch = "bitvm"
-
-[patch.crates-io.bitcoin]
-git = "https://github.com/rust-bitcoin/rust-bitcoin"
-branch = "bitvm"
-
-[patch.crates-io.bitcoin_hashes]
-git = "https://github.com/rust-bitcoin/rust-bitcoin"
-branch = "bitvm"
-
-[patch.crates-io.bitcoin-internals]
-git = "https://github.com/rust-bitcoin/rust-bitcoin"
-branch = "bitvm"
-
-[patch.crates-io.bitcoin-io]
-git = "https://github.com/rust-bitcoin/rust-bitcoin"
-branch = "bitvm"
-
-[patch.crates-io.bitcoin-units]
-git = "https://github.com/rust-bitcoin/rust-bitcoin"
-branch = "bitvm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoin-script-stack"
-description = "Bitcoin script stack tracking tool and deubgger"
 version = "0.0.1"
+description = "Bitcoin script stack tracking tool and debugger"
 edition = "2021"
 authors = ["Martin Jonas <martinjonas@gmail.com>"]
 repository = "https://github.com/FairgateLabs/rust-bitcoin-script-stack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/FairgateLabs/rust-bitcoin-script-stack"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
-bitcoin-scriptexec = { git = "https://github.com/BitVM/rust-bitcoin-scriptexec/"}
+bitcoin-script = { git = "https://github.com/alpenlabs/rust-bitcoin-script", branch = "bitcoin-0.32.5" }         # TODO: remove the fork and branch once merged
 bitcoin = "0.32.5"
+bitcoin-scriptexec = { git = "https://github.com/alpenlabs/rust-bitcoin-scriptexec", branch = "bitcoin-0.32.5" } # TODO: remove the fork and branch once merged
 crossterm = { version = "0.27.0", optional = true }
 hex = "0.4.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoin-script-stack"
-version = "0.0.1"
 description = "Bitcoin script stack tracking tool and debugger"
+version = "0.0.2"
 edition = "2021"
 authors = ["Martin Jonas <martinjonas@gmail.com>"]
 repository = "https://github.com/FairgateLabs/rust-bitcoin-script-stack"


### PR DESCRIPTION
Related to https://github.com/rust-bitcoin/rust-bitcoin/pull/3729.

Keeping this as a draft since I am planning to do PRs in more `BitVM` org crates to bump `rust-bitcoin` to 0.32.5 (latest).

Oops. Closed by #3.