### PR TITLE
Use hex-conservative

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 bitcoin = "0.32.5"
 bitcoin-scriptexec = { git = "https://github.com/BitVM/rust-bitcoin-scriptexec" }
 crossterm = { version = "0.27.0", optional = true }
-hex = "0.4.3"
 
 [features]
 interactive = ["crossterm"]

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -38,7 +38,7 @@ fn get_digit(instruction: &Instruction) -> Option<u8> {
             }
         }, 
         Instruction::PushBytes(x) => { // zero bytes is op_0
-            if x.as_bytes().len() == 0 {
+            if x.as_bytes().is_empty() {
                 return Some(0);
             }
         }
@@ -48,12 +48,12 @@ fn get_digit(instruction: &Instruction) -> Option<u8> {
 
 fn get_opcode(instruction: &Instruction) -> Option<Opcode> {
     match instruction {
-        Instruction::Op(op) => Some(op.clone()),
+        Instruction::Op(op) => Some(*op),
         _ => None
     }
 }
 
-fn count_ahead(instructions: &Vec<Instruction>, i: usize) -> usize {
+fn count_ahead(instructions: &[Instruction], i: usize) -> usize {
     let mut j = i + 1;
     let mut count = 0;
     while j < instructions.len() {

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use bitcoin::{opcodes::OP_TRUE, Opcode};
+use bitcoin::{opcodes::OP_TRUE, Opcode, hex::FromHex};
 use bitcoin::opcodes::all::*;
 
 pub use bitcoin_script::script;
@@ -8,8 +8,6 @@ pub use bitcoin_script::builder::StructuredScript as Script;
 
 use crate::debugger::{execute_step, print_execute_step, show_altstack, show_stack, StepResult};
 use super::script_util::*;
-
-use hex::FromHex;
 
 
 #[derive(Clone, Debug, Copy)]

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -515,7 +515,7 @@ impl StackTracker {
             self.data.pop_stack();
         }
 
-        if output_vars.len() > 0 {
+        if !output_vars.is_empty() {
             let mut ret = Vec::new();
 
             for (size, name) in output_vars {
@@ -537,10 +537,10 @@ impl StackTracker {
     pub fn custom(&mut self, script: Script, consumes: u32, output: bool, to_altstack: u32, name: &str ) -> Option<StackVariable> {
         let mut output_vec = vec![];
         if output {
-            output_vec.push((1 as u32, name.to_string()));
+            output_vec.push((1u32, name.to_string()));
         }
         let ret = self.custom_ex(script, consumes, output_vec, to_altstack);
-        if ret.len() == 0 {
+        if ret.is_empty() {
             None
         } else {
             Some(ret[0])


### PR DESCRIPTION
This PR removes the hex crate dependency in favor of hex-conservative, which is bundled with rust-bitcoin.

I also fixed some clippy lints.